### PR TITLE
サインアップ後のメール認証完了後、認証コード入力なしでサインアップを完了させるように実装

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,7 @@ Amplify.configure({
   },
 });
 
-const kimonoApp = ({ Component, pageProps }: AppProps): ReactElement => {
+const CustomApp = ({ Component, pageProps }: AppProps): ReactElement => {
   return (
     <Provider store={createStore()}>
       <Component {...pageProps} />
@@ -22,4 +22,4 @@ const kimonoApp = ({ Component, pageProps }: AppProps): ReactElement => {
   );
 };
 
-export default kimonoApp;
+export default CustomApp;

--- a/src/pages/cognito/signup/confirm.tsx
+++ b/src/pages/cognito/signup/confirm.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+import { Auth } from 'aws-amplify';
+
+type Props = {
+  user?: { sub: string };
+  error?: Error;
+};
+
+const Confirm: React.FC<Props> = ({ user, error }: Props) => {
+  return (
+    <>
+      {error ? <div>エラーが発生しました。 {error.message}</div> : ''}
+      {user ? <div>{user.sub} の登録が完了しました！</div> : ''}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  try {
+    const { sub, code } = context.query;
+
+    if (sub === undefined || code === undefined) {
+      return {
+        props: {},
+      };
+    }
+
+    // 返り値はSUCCESSという文字列が返ってくるだけ
+    await Auth.confirmSignUp(String(sub), String(code));
+
+    return { props: { user: { sub } } };
+  } catch (e) {
+    return { props: { error: e } };
+  }
+};
+
+export default Confirm;


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/next-idaas/issues/10

# やった事

新しいエンドポイント `/cognito/signup/confirm` を作成、この中でCognitoのサインアップ完了処理を行うように実装。

なおこのURLへのリンクは https://github.com/keitakn/go-cognito-lambda/issues/4 のCustomMessage内から生成されるので常に `getServerSideProps` が実行される想定。

このコードはサンプルなので最低限の実装だが、実践的なコードでもpagesComponent内の `getServerSideProps` 内で処理を実施する形で良いと思われる。

## 正常に登録が完了した場合

`{Cognitoのsubが表示}` の登録が完了しました！

## 何らかのエラーが発生した場合

エラーが発生しました。 `エラーメッセージが表示される`