### PR TITLE
認証状態を維持出来るようにJWTトークンの検証ロジックを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@aws-amplify/ui-react": "^0.2.13",
     "@reduxjs/toolkit": "^1.4.0",
     "aws-amplify": "^3.0.22",
+    "jsonwebtoken": "^8.5.1",
+    "jwk-to-pem": "^2.0.4",
     "next": "^9.4.4",
     "nookies": "^2.3.2",
     "react": "^16.13.1",
@@ -24,6 +26,8 @@
   },
   "devDependencies": {
     "@types/eslint-plugin-prettier": "^3.1.0",
+    "@types/jsonwebtoken": "^8.5.0",
+    "@types/jwk-to-pem": "^2.0.0",
     "@types/node": "^14.0.22",
     "@types/prettier": "^2.0.2",
     "@types/react": "^16.9.42",

--- a/src/domain/cognito.ts
+++ b/src/domain/cognito.ts
@@ -1,0 +1,142 @@
+import jwkToPem from 'jwk-to-pem';
+import jwt from 'jsonwebtoken';
+
+type Jwk = {
+  alg: 'RS256';
+  e: 'AQAB';
+  kid: string;
+  kty: 'RSA';
+  n: string;
+  use: 'sig';
+};
+
+type Jwks = {
+  keys: Jwk[];
+};
+
+type CognitoPublicPem = string;
+
+type CognitoPublicPems = {
+  [region: string]: {
+    [userPoolId: string]: {
+      [kid: string]: CognitoPublicPem;
+    };
+  };
+};
+
+type CognitoIdToken = {
+  // eslint-disable-next-line camelcase
+  at_hash: string;
+  sub: string;
+  'cognito:groups': string[];
+  email: string;
+  // eslint-disable-next-line camelcase
+  email_verified: false;
+  iss: string;
+  aud: string;
+  identities: { [key: string]: string | number }[];
+  // eslint-disable-next-line camelcase
+  token_use: 'id';
+  // eslint-disable-next-line camelcase
+  auth_time: number;
+  exp: number;
+  iat: number;
+};
+
+export const cognitoRegion = (): string => {
+  return process.env.NEXT_PUBLIC_COGNITO_REGION
+    ? process.env.NEXT_PUBLIC_COGNITO_REGION
+    : '';
+};
+
+export const cognitoUserPoolId = (): string => {
+  return process.env.NEXT_PUBLIC_USER_POOL_ID
+    ? process.env.NEXT_PUBLIC_USER_POOL_ID
+    : '';
+};
+
+export const cognitoUserPoolClientId = (): string => {
+  return process.env.NEXT_PUBLIC_SPA_CLIENT_ID
+    ? process.env.NEXT_PUBLIC_SPA_CLIENT_ID
+    : '';
+};
+
+export const cognitoJwksUrl = (): string => {
+  return `https://cognito-idp.${cognitoRegion()}.amazonaws.com/${cognitoUserPoolId()}/.well-known/jwks.json`;
+};
+
+const fetchCognitoJwks = async (): Promise<Jwks> => {
+  const jwksResponse = await fetch(cognitoJwksUrl());
+
+  const jwks = await jwksResponse.json();
+
+  return jwks;
+};
+
+const createPublicPems = (jwks: Jwks) => {
+  const region = cognitoRegion();
+  const userPoolId = cognitoUserPoolId();
+
+  return jwks.keys.reduce((cognitoPublicPems: CognitoPublicPems, key: Jwk) => {
+    if (!cognitoPublicPems[region])
+      // eslint-disable-next-line no-param-reassign
+      cognitoPublicPems[region] = { [userPoolId]: {} };
+    if (!cognitoPublicPems[region][userPoolId])
+      // eslint-disable-next-line no-param-reassign
+      cognitoPublicPems[region][userPoolId] = {};
+    // eslint-disable-next-line no-param-reassign
+    cognitoPublicPems[region][userPoolId][key.kid] = jwkToPem(key);
+
+    return cognitoPublicPems;
+  }, {});
+};
+
+const extractPem = (
+  cognitoPublicPems: CognitoPublicPems,
+  token: string,
+): CognitoPublicPem => {
+  const jwtTokenList = token.split('.');
+
+  const header = JSON.parse(Buffer.from(jwtTokenList[0], 'base64').toString());
+
+  const region = cognitoRegion();
+  const userPoolId = cognitoUserPoolId();
+
+  return cognitoPublicPems[region][userPoolId][header.kid];
+};
+
+export const verifyIdToken = async (
+  idToken: string,
+): Promise<CognitoIdToken> => {
+  // .well-known/jwks.json からJWKセットを取得
+  // ここはCache出来るかも
+  const jwks = await fetchCognitoJwks();
+
+  // PEM形式のRSA鍵を生成する
+  const publicPems = createPublicPems(jwks);
+
+  // トークンに使われているPEM形式のRSA鍵を取り出す
+  const pem = extractPem(publicPems, idToken);
+
+  // IDトークンの検証を行う
+  const cognitoIdToken = jwt.verify(idToken, pem, {
+    algorithms: ['RS256'],
+  }) as CognitoIdToken;
+
+  // トークンの発行元を確認
+  if (
+    cognitoIdToken.iss !==
+    `https://cognito-idp.${cognitoRegion()}.amazonaws.com/${cognitoUserPoolId()}`
+  ) {
+    return Promise.reject(new Error('トークンの発行元が違います。'));
+  }
+
+  // トークンが自身のClientIDに対して発行されているか確認する
+  if (cognitoIdToken.aud !== cognitoUserPoolClientId()) {
+    return Promise.reject(
+      new Error('自身のClientIDに対して発行されたトークンではありません。'),
+    );
+  }
+
+  return cognitoIdToken;
+};

--- a/src/infrastructure/Cookie.ts
+++ b/src/infrastructure/Cookie.ts
@@ -3,9 +3,11 @@ import {
   setCookie as nookiesSetCookie,
   destroyCookie as nookiesDestroyCookie,
 } from 'nookies';
-import { NextPageContext } from 'next';
+import { NextPageContext, GetServerSidePropsContext } from 'next';
 
-export const findCookies = <T>(ctx?: NextPageContext): T => {
+export const findCookies = <T>(
+  ctx?: NextPageContext | GetServerSidePropsContext,
+): T => {
   const cookies: any = parseCookies(ctx);
 
   return cookies as T;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,7 +21,7 @@ Amplify.configure({
   oauth: {
     domain: process.env.NEXT_PUBLIC_COGNITO_DOMAIN,
     scope: ['profile', 'email', 'openid'],
-    redirectSignIn: `${process.env.NEXT_PUBLIC_APP_URL}/cognito/authorized`,
+    redirectSignIn: `${process.env.NEXT_PUBLIC_APP_URL}/cognito/callback`,
     redirectSignOut: `${process.env.NEXT_PUBLIC_APP_URL}/cognito/logout`,
     responseType: 'code',
   },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,12 @@ Amplify.configure({
     userPoolWebClientId: process.env.NEXT_PUBLIC_SPA_CLIENT_ID,
     mandatorySignIn: false,
     authenticationFlowType: 'USER_PASSWORD_AUTH',
+    cookieStorage: {
+      domain: process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN,
+      path: '/',
+      expires: 7,
+      secure: false,
+    },
   },
   oauth: {
     domain: process.env.NEXT_PUBLIC_COGNITO_DOMAIN,

--- a/src/pages/cognito/authorized.tsx
+++ b/src/pages/cognito/authorized.tsx
@@ -1,7 +1,127 @@
 import React from 'react';
+import { GetServerSideProps } from 'next';
+import jwkToPem from 'jwk-to-pem';
+import jwt from 'jsonwebtoken';
+import { findCookies } from '../../infrastructure/Cookie';
 
-export const AuthorizedPage: React.FC = (): JSX.Element => {
-  return <div>（仮）Cognitoで認証・認可済のユーザーが入れるページ</div>;
+const extractPem = (
+  cognitoPublicPems: CognitoPublicPems,
+  token: string,
+  region: string,
+  userPoolId: string,
+) => {
+  const jwtTokenList = token.split('.');
+
+  const header = JSON.parse(Buffer.from(jwtTokenList[0], 'base64').toString());
+
+  return cognitoPublicPems[region][userPoolId][header.kid];
+};
+
+type Props = {
+  user?: { sub: string };
+};
+
+export const AuthorizedPage: React.FC<Props> = ({
+  user,
+}: Props): JSX.Element => {
+  return (
+    <>
+      {user ? (
+        <div>
+          Cognitoで認証済のユーザーです。 ユーザーIDは {user.sub} です！
+        </div>
+      ) : (
+        ''
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookies = findCookies<{ [key: string]: string }>(context);
+
+  const keyPrefix = `CognitoIdentityServiceProvider.${process.env.NEXT_PUBLIC_SPA_CLIENT_ID}`;
+  const userNameKey = `${keyPrefix}.LastAuthUser`;
+
+  const userName = cookies[userNameKey];
+
+  const idTokenKey = `${keyPrefix}.${userName}.idToken`;
+
+  const idToken = cookies[idTokenKey];
+
+  const region = process.env.NEXT_PUBLIC_COGNITO_REGION
+    ? process.env.NEXT_PUBLIC_COGNITO_REGION
+    : '';
+  const userPoolId = process.env.NEXT_PUBLIC_USER_POOL_ID
+    ? process.env.NEXT_PUBLIC_USER_POOL_ID
+    : '';
+
+  const jwksUrl = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`;
+  const jwksResponse = await fetch(jwksUrl);
+
+  const jwks = await jwksResponse.json();
+
+  const publicPems = jwks.keys.reduce(
+    (cognitoPublicPems: CognitoPublicPems, key: Jwk) => {
+      if (!cognitoPublicPems[region])
+        // eslint-disable-next-line no-param-reassign
+        cognitoPublicPems[region] = { [userPoolId]: {} };
+      if (!cognitoPublicPems[region][userPoolId])
+        // eslint-disable-next-line no-param-reassign
+        cognitoPublicPems[region][userPoolId] = {};
+      // eslint-disable-next-line no-param-reassign
+      cognitoPublicPems[region][userPoolId][key.kid] = jwkToPem(key);
+
+      return cognitoPublicPems;
+    },
+    {},
+  );
+
+  const pem = extractPem(publicPems, idToken, region, userPoolId);
+
+  const cognitoIdToken = jwt.verify(idToken, pem, {
+    algorithms: ['RS256'],
+  }) as CognitoIdToken;
+
+  return { props: { user: { sub: cognitoIdToken.sub } } };
+};
+
+type Jwk = {
+  alg: 'RS256';
+  e: 'AQAB';
+  kid: string;
+  kty: 'RSA';
+  n: string;
+  use: 'sig';
+};
+
+type CognitoPublicPem = string;
+
+type CognitoPublicPems = {
+  [region: string]: {
+    [userPoolId: string]: {
+      [kid: string]: CognitoPublicPem;
+    };
+  };
+};
+
+type CognitoIdToken = {
+  // eslint-disable-next-line camelcase
+  at_hash: string;
+  sub: string;
+  'cognito:groups': string[];
+  email: string;
+  // eslint-disable-next-line camelcase
+  email_verified: false;
+  iss: string;
+  aud: string;
+  identities: { [key: string]: string | number }[];
+  // eslint-disable-next-line camelcase
+  token_use: 'id';
+  // eslint-disable-next-line camelcase
+  auth_time: number;
+  exp: number;
+  iat: number;
 };
 
 export default AuthorizedPage;

--- a/src/pages/cognito/authorized.tsx
+++ b/src/pages/cognito/authorized.tsx
@@ -1,21 +1,7 @@
 import React from 'react';
 import { GetServerSideProps } from 'next';
-import jwkToPem from 'jwk-to-pem';
-import jwt from 'jsonwebtoken';
 import { findCookies } from '../../infrastructure/Cookie';
-
-const extractPem = (
-  cognitoPublicPems: CognitoPublicPems,
-  token: string,
-  region: string,
-  userPoolId: string,
-) => {
-  const jwtTokenList = token.split('.');
-
-  const header = JSON.parse(Buffer.from(jwtTokenList[0], 'base64').toString());
-
-  return cognitoPublicPems[region][userPoolId][header.kid];
-};
+import { verifyIdToken } from '../../domain/cognito';
 
 type Props = {
   user?: { sub: string };
@@ -49,79 +35,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const idToken = cookies[idTokenKey];
 
-  const region = process.env.NEXT_PUBLIC_COGNITO_REGION
-    ? process.env.NEXT_PUBLIC_COGNITO_REGION
-    : '';
-  const userPoolId = process.env.NEXT_PUBLIC_USER_POOL_ID
-    ? process.env.NEXT_PUBLIC_USER_POOL_ID
-    : '';
-
-  const jwksUrl = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`;
-  const jwksResponse = await fetch(jwksUrl);
-
-  const jwks = await jwksResponse.json();
-
-  const publicPems = jwks.keys.reduce(
-    (cognitoPublicPems: CognitoPublicPems, key: Jwk) => {
-      if (!cognitoPublicPems[region])
-        // eslint-disable-next-line no-param-reassign
-        cognitoPublicPems[region] = { [userPoolId]: {} };
-      if (!cognitoPublicPems[region][userPoolId])
-        // eslint-disable-next-line no-param-reassign
-        cognitoPublicPems[region][userPoolId] = {};
-      // eslint-disable-next-line no-param-reassign
-      cognitoPublicPems[region][userPoolId][key.kid] = jwkToPem(key);
-
-      return cognitoPublicPems;
-    },
-    {},
-  );
-
-  const pem = extractPem(publicPems, idToken, region, userPoolId);
-
-  const cognitoIdToken = jwt.verify(idToken, pem, {
-    algorithms: ['RS256'],
-  }) as CognitoIdToken;
+  const cognitoIdToken = await verifyIdToken(idToken);
 
   return { props: { user: { sub: cognitoIdToken.sub } } };
-};
-
-type Jwk = {
-  alg: 'RS256';
-  e: 'AQAB';
-  kid: string;
-  kty: 'RSA';
-  n: string;
-  use: 'sig';
-};
-
-type CognitoPublicPem = string;
-
-type CognitoPublicPems = {
-  [region: string]: {
-    [userPoolId: string]: {
-      [kid: string]: CognitoPublicPem;
-    };
-  };
-};
-
-type CognitoIdToken = {
-  // eslint-disable-next-line camelcase
-  at_hash: string;
-  sub: string;
-  'cognito:groups': string[];
-  email: string;
-  // eslint-disable-next-line camelcase
-  email_verified: false;
-  iss: string;
-  aud: string;
-  identities: { [key: string]: string | number }[];
-  // eslint-disable-next-line camelcase
-  token_use: 'id';
-  // eslint-disable-next-line camelcase
-  auth_time: number;
-  exp: number;
-  iat: number;
 };
 
 export default AuthorizedPage;

--- a/src/pages/cognito/callback.tsx
+++ b/src/pages/cognito/callback.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+
+export const CallbackPage: React.FC = (): JSX.Element => {
+  return <div>Cognito Callback URL</div>;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  context.res.writeHead(302, { Location: '/cognito/authorized' });
+  context.res.end();
+
+  return { props: {} };
+};
+
+export default CallbackPage;

--- a/src/pages/cognito/callback.tsx
+++ b/src/pages/cognito/callback.tsx
@@ -1,15 +1,13 @@
-import React from 'react';
-import { GetServerSideProps } from 'next';
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 export const CallbackPage: React.FC = (): JSX.Element => {
-  return <div>Cognito Callback URL</div>;
-};
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/cognito/authorized');
+  });
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  context.res.writeHead(302, { Location: '/cognito/authorized' });
-  context.res.end();
-
-  return { props: {} };
+  return <div>認証後のページにリダイレクトします。少々お待ち下さい。</div>;
 };
 
 export default CallbackPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
+import Link from 'next/link';
 
 const IndexPage: React.FC = () => {
   return (
     <>
       <h1>Next.js + IDaaS(Identity as a Service)</h1>
+      <div>
+        <ul>
+          <li>
+            <Link href="/cognito/signup">Cognitoでサインアップ</Link>
+          </li>
+          <li>
+            <Link href="/cognito/signin">Cognitoでサインイン</Link>
+          </li>
+          <li>
+            <Link href="/cognito/authorized">
+              Cognitoでサインイン済じゃないと見れないページ
+            </Link>
+          </li>
+        </ul>
+      </div>
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,6 +2378,23 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/jsonwebtoken@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
+  integrity sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/jwk-to-pem@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jwk-to-pem/-/jwk-to-pem-2.0.0.tgz#770ad9cc70134d47283b3c815a064a06f802d065"
+  integrity sha512-m7ZnE+iJodvhu9XNkMc/1CNkIg7432d/YSB8Qo/4TbD86rZ1GgkB4MVTNqIZG5RCtL0H4iVxiMT2OGTQDZEfHg==
+
+"@types/node@*":
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.0.tgz#7d4411bf5157339337d7cff864d9ff45f177b499"
+  integrity sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
+
 "@types/node@^14.0.22":
   version "14.0.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.22.tgz#23ea4d88189cec7d58f9e6b66f786b215eb61bdc"
@@ -2890,6 +2907,16 @@ asn1.js@^4.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
+asn1.js@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
+
 assert@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
@@ -3194,6 +3221,11 @@ buffer-alloc@^1.2.0:
   dependencies:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-fill@^1.0.0:
   version "1.0.0"
@@ -4099,12 +4131,19 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 electron-to-chromium@^1.3.413, electron-to-chromium@^1.3.488:
   version "1.3.496"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz#3f43d32930481d82ad3663d79658e7c59a58af0b"
   integrity sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ==
 
-elliptic@^6.0.0, elliptic@^6.5.2:
+elliptic@^6.0.0, elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -5392,6 +5431,22 @@ json5@^2.1.0, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsx-ast-utils@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"
@@ -5404,6 +5459,32 @@ just-extend@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.0.tgz#7278a4027d889601640ee0ce0e5a00b992467da4"
   integrity sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwk-to-pem@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jwk-to-pem/-/jwk-to-pem-2.0.4.tgz#774e168697a0b52054e8cfb0bcd57e0f4c398e2d"
+  integrity sha512-4CCK9UBHNWjWtfSHdyu3I6rA8vlN5cWqnVuwY0cOMyXtw6M1tP+yrM8GZpwk+P932Dc3cLag4d35B6CqyIf89A==
+  dependencies:
+    asn1.js "^5.3.0"
+    elliptic "^6.5.3"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5526,10 +5607,45 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -7205,6 +7321,11 @@ safe-regex@^1.1.0:
   integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
   dependencies:
     ret "~0.1.10"
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sass-loader@8.0.2:
   version "8.0.2"


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/next-idaas/issues/15

# やった事
認証済のページ `/cognito/authorized` を実装、この中でCognitoのIDトークンを検証し問題ない場合はユーザーIDを表示させる処理を行っている。

Error処理が現時点では出来ていないのでログアウト状態だと、Errorページが表示されてしまう。

しかし認証状態を確認するという目的は達成しているのでこのPRの範囲はここまでとする。