### PR TITLE
サインアップフォームをaws-amplifyを使った形に置き換え

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@aws-amplify/ui-components": "^0.6.2",
     "@aws-amplify/ui-react": "^0.2.15",
     "@reduxjs/toolkit": "^1.4.0",
+    "amazon-cognito-identity-js": "^4.3.4",
     "aws-amplify": "^3.0.22",
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.4",

--- a/src/pages/cognito/signup.tsx
+++ b/src/pages/cognito/signup.tsx
@@ -1,29 +1,100 @@
 import React from 'react';
-import { AmplifyAuthenticator, AmplifySignUp } from '@aws-amplify/ui-react';
+import { Auth } from 'aws-amplify';
 
 const SignupPage: React.FC = () => {
+  const [email, setEmail] = React.useState<string>('');
+  const [password, setPassword] = React.useState<string>('');
+  const [errorCode, setErrorCode] = React.useState<string>();
+  const [errorMessage, setErrorMessage] = React.useState<string>();
+  const [sendSignUp, setSendSignUp] = React.useState<boolean>(false);
+  const [resendSignUp, setResendSignUp] = React.useState<boolean>(false);
+
+  const changedEmailHandler = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setEmail(event.target.value.trim());
+  const changedPasswordHandler = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setPassword(event.target.value.trim());
+
+  const handleSignUpSubmit = async () => {
+    setSendSignUp(false);
+
+    try {
+      if (!email || !password) {
+        return;
+      }
+
+      await Auth.signUp({
+        username: email,
+        password,
+      });
+
+      setSendSignUp(true);
+      setErrorMessage('');
+    } catch (e) {
+      setErrorCode(e.code);
+      setErrorMessage(e.message);
+    }
+  };
+
+  const handleResendSignUp = async () => {
+    setResendSignUp(false);
+
+    try {
+      if (!email) {
+        return;
+      }
+
+      await Auth.resendSignUp(email);
+      setErrorMessage('');
+      setResendSignUp(true);
+    } catch (e) {
+      setErrorCode(e.code);
+      setErrorMessage(e.message);
+    }
+  };
+
+  const inputStyle = {
+    width: 300,
+    height: 25,
+  };
+
+  const errorStyle = {
+    color: 'red',
+  };
+
   return (
-    <AmplifyAuthenticator>
-      <AmplifySignUp
-        headerText="Sign Up"
-        slot="sign-up"
-        usernameAlias="email"
-        formFields={[
-          {
-            type: 'email',
-            label: 'メールアドレス(必須)',
-            placeholder: '',
-            required: true,
-          },
-          {
-            type: 'password',
-            label: 'パスワード(必須)',
-            placeholder: '',
-            required: true,
-          },
-        ]}
-      />
-    </AmplifyAuthenticator>
+    <>
+      <h1>CognitoでSignUp</h1>
+      <form method="post">
+        <input
+          style={inputStyle}
+          type="text"
+          placeholder="email"
+          onChange={changedEmailHandler}
+        />
+        <input
+          style={inputStyle}
+          type="password"
+          placeholder="password"
+          onChange={changedPasswordHandler}
+        />
+        <button type="button" onClick={handleSignUpSubmit}>
+          登録する
+        </button>
+        {errorCode === 'UsernameExistsException' ? (
+          <button type="button" onClick={handleResendSignUp}>
+            認証メールを再送する
+          </button>
+        ) : (
+          ''
+        )}
+      </form>
+      {sendSignUp || resendSignUp ? (
+        <div>{email} に認証メールを送信しました。メールをご確認下さい。</div>
+      ) : (
+        ''
+      )}
+      {errorMessage ? <div style={errorStyle}>{errorMessage}</div> : ''}
+    </>
   );
 };
 


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/next-idaas/issues/18

# やった事
`@aws-amplify/ui-react` を使うのを止めて、`aws-amplify` を使って自前でUIを組み立てるように変更。

# スクリーンショット

![cognito_signup](https://user-images.githubusercontent.com/11032365/91175652-170c3d00-e71c-11ea-91bf-c24cc5c26f05.png)

# 問題点

https://github.com/keitakn/go-cognito-lambda/blob/master/message/main.go を使ってメール認証のみでサインアップを完了させるようにしている。

しかし認証メールを再送する際には https://github.com/keitakn/go-cognito-lambda/blob/master/message/main.go のCustomMessageが適応されないので https://github.com/keitakn/go-cognito-lambda/issues/8 の課題で対応を行う。