### PR TITLE
Cognitoのパスワードリセットフォームの実装

### DIFF
--- a/src/pages/cognito/password/reset.tsx
+++ b/src/pages/cognito/password/reset.tsx
@@ -39,6 +39,7 @@ const reducer = (
   state: State,
   action:
     | ReturnType<typeof actions.postPasswordResetStart>
+    | ReturnType<typeof actions.postPasswordResetSuccess>
     | ReturnType<typeof actions.postPasswordResetError>,
 ) => {
   switch (action.type) {

--- a/src/pages/cognito/password/reset.tsx
+++ b/src/pages/cognito/password/reset.tsx
@@ -20,7 +20,7 @@ const PasswordResetForm = () => {
     setSendVerificationCode(false);
 
     try {
-      await Auth.forgotPassword(email);
+      await Auth.forgotPassword(email, { email });
 
       setSendVerificationCode(true);
       setSentEmail(email);

--- a/src/pages/cognito/password/reset.tsx
+++ b/src/pages/cognito/password/reset.tsx
@@ -1,7 +1,7 @@
 import { Auth } from 'aws-amplify';
 import React from 'react';
 
-export const SignInPage: React.FC = (): JSX.Element => {
+export const PasswordResetPage: React.FC = (): JSX.Element => {
   const [email, setEmail] = React.useState<string>('');
   const [errorMessage, setErrorMessage] = React.useState<string>();
   const [sendVerificationCode, setSendVerificationCode] = React.useState<
@@ -65,4 +65,4 @@ export const SignInPage: React.FC = (): JSX.Element => {
   );
 };
 
-export default SignInPage;
+export default PasswordResetPage;

--- a/src/pages/cognito/password/reset.tsx
+++ b/src/pages/cognito/password/reset.tsx
@@ -1,7 +1,7 @@
 import { Auth } from 'aws-amplify';
 import React from 'react';
 
-export const PasswordResetPage: React.FC = (): JSX.Element => {
+export const ResetPage: React.FC = (): JSX.Element => {
   const [email, setEmail] = React.useState<string>('');
   const [errorMessage, setErrorMessage] = React.useState<string>();
   const [sendVerificationCode, setSendVerificationCode] = React.useState<
@@ -65,4 +65,4 @@ export const PasswordResetPage: React.FC = (): JSX.Element => {
   );
 };
 
-export default PasswordResetPage;
+export default ResetPage;

--- a/src/pages/cognito/password/reset.tsx
+++ b/src/pages/cognito/password/reset.tsx
@@ -1,0 +1,68 @@
+import { Auth } from 'aws-amplify';
+import React from 'react';
+
+export const SignInPage: React.FC = (): JSX.Element => {
+  const [email, setEmail] = React.useState<string>('');
+  const [errorMessage, setErrorMessage] = React.useState<string>();
+  const [sendVerificationCode, setSendVerificationCode] = React.useState<
+    boolean
+  >(false);
+
+  const changedEmailHandler = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setEmail(event.target.value.trim());
+
+  const handlePasswordResetSubmit = async () => {
+    if (!email) {
+      return;
+    }
+
+    setSendVerificationCode(false);
+
+    try {
+      await Auth.forgotPassword(email);
+
+      setErrorMessage('');
+
+      setSendVerificationCode(true);
+    } catch (e) {
+      setErrorMessage(e.message);
+    }
+  };
+
+  const inputStyle = {
+    width: 250,
+    height: 25,
+  };
+
+  const errorStyle = {
+    color: 'red',
+  };
+
+  return (
+    <>
+      <h1>Cognito パスワードリセット</h1>
+      <form method="post">
+        <input
+          style={inputStyle}
+          type="text"
+          placeholder="email"
+          onChange={changedEmailHandler}
+        />
+        <button type="button" onClick={handlePasswordResetSubmit}>
+          パスワードリセット用のメールを送信する
+        </button>
+      </form>
+      {sendVerificationCode ? (
+        <div>
+          {email}{' '}
+          にパスワードリセット用の認証メールを送信しました。メールをご確認下さい。
+        </div>
+      ) : (
+        ''
+      )}
+      {errorMessage ? <div style={errorStyle}>{errorMessage}</div> : ''}
+    </>
+  );
+};
+
+export default SignInPage;

--- a/src/pages/cognito/password/reset/confirm.tsx
+++ b/src/pages/cognito/password/reset/confirm.tsx
@@ -61,6 +61,13 @@ const ConfirmPage: React.FC<Props> = ({ user, code, error }: Props) => {
       </form>
       {error ? <div style={errorStyle}>{error.message}</div> : ''}
       {errorMessage ? <div style={errorStyle}>{errorMessage}</div> : ''}
+      {error || errorMessage ? (
+        <Link href="/cognito/password/reset">
+          パスワードリセットを最初からやり直す
+        </Link>
+      ) : (
+        ''
+      )}
       {passwordResetCompleted ? (
         <div>
           新しいパスワードに変更しました。{' '}

--- a/src/pages/cognito/password/reset/confirm.tsx
+++ b/src/pages/cognito/password/reset/confirm.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+import { Auth } from 'aws-amplify';
+import Link from 'next/link';
+
+type Props = {
+  user?: {
+    sub: string;
+  };
+  code?: string;
+  error?: Error;
+};
+
+const ConfirmPage: React.FC<Props> = ({ user, code, error }: Props) => {
+  const [newPassword, setNewPassword] = React.useState<string>('');
+  const [errorMessage, setErrorMessage] = React.useState<string>('');
+  const [passwordResetCompleted, setPasswordResetCompleted] = React.useState<
+    boolean
+  >(false);
+
+  const changedNewPasswordHandler = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => setNewPassword(event.target.value.trim());
+
+  const handleNewPasswordSubmit = async () => {
+    if (!user || !code) {
+      return;
+    }
+
+    try {
+      await Auth.forgotPasswordSubmit(user.sub, code, newPassword);
+
+      setPasswordResetCompleted(true);
+    } catch (e) {
+      setErrorMessage(e.message);
+    }
+  };
+
+  const inputStyle = {
+    width: 250,
+    height: 25,
+  };
+
+  const errorStyle = {
+    color: 'red',
+  };
+
+  return (
+    <>
+      <h1>Cognito パスワードリセットを完了させる</h1>
+      <form method="post">
+        <input
+          style={inputStyle}
+          type="password"
+          placeholder="新しいパスワード"
+          onChange={changedNewPasswordHandler}
+        />
+        <button type="button" onClick={handleNewPasswordSubmit}>
+          パスワードリセットを完了させる
+        </button>
+      </form>
+      {error ? <div style={errorStyle}>{error.message}</div> : ''}
+      {errorMessage ? <div style={errorStyle}>{errorMessage}</div> : ''}
+      {passwordResetCompleted ? (
+        <div>
+          新しいパスワードに変更しました。{' '}
+          <Link href="/cognito/signin">Cognitoでサインイン</Link>{' '}
+          からサインインを行って下さい。
+        </div>
+      ) : (
+        ''
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  try {
+    const { sub, code } = context.query;
+
+    if (sub === undefined || code === undefined) {
+      return {
+        props: {},
+      };
+    }
+
+    return {
+      props: {
+        code: String(code),
+        user: { sub: String(sub) },
+      },
+    };
+  } catch (e) {
+    return { props: { error: e } };
+  }
+};
+
+export default ConfirmPage;

--- a/src/pages/cognito/signin.tsx
+++ b/src/pages/cognito/signin.tsx
@@ -2,6 +2,7 @@ import { Auth } from 'aws-amplify';
 import React from 'react';
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 export const SignInPage: React.FC = (): JSX.Element => {
   const [email, setEmail] = React.useState<string>('');
@@ -115,6 +116,7 @@ export const SignInPage: React.FC = (): JSX.Element => {
       <button type="button" onClick={handleFacebookLoginClick}>
         Facebookでログイン
       </button>
+      <Link href="/cognito/password/reset">パスワードを忘れた方はこちら</Link>
     </>
   );
 };


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/next-idaas/issues/23

# やった事
パスワードをリセットする為のformを実装。

本当は認証コードと新しいパスワードの2種類を入れる必要があるが https://github.com/keitakn/go-cognito-lambda/issues/11 でメッセージをカスタマイズしたので、認証URLを踏んで新しいパスワードを入力するだけで完了にするようになっています。