### PR TITLE
ログイン後のページにFacebookのプロフィール画像と名前を表示させるように変更

### DIFF
--- a/src/domain/cognito.ts
+++ b/src/domain/cognito.ts
@@ -34,7 +34,14 @@ type CognitoIdToken = {
   email_verified: false;
   iss: string;
   aud: string;
-  identities: { [key: string]: string | number }[];
+  identities: {
+    userId: string;
+    providerName: string;
+    providerType: string;
+    issuer: string | null;
+    primary: string;
+    dateCreated: string;
+  }[];
   // eslint-disable-next-line camelcase
   token_use: 'id';
   // eslint-disable-next-line camelcase
@@ -139,4 +146,25 @@ export const verifyIdToken = async (
   }
 
   return cognitoIdToken;
+};
+
+export const extractFacebookSubFromCognitoIdToken = (
+  cognitoIdToken: CognitoIdToken,
+): string => {
+  if (!cognitoIdToken.identities) {
+    return '';
+  }
+
+  if (
+    !cognitoIdToken.identities[0].providerName ||
+    !cognitoIdToken.identities[0].userId
+  ) {
+    return '';
+  }
+
+  if (cognitoIdToken.identities[0].providerName !== 'Facebook') {
+    return '';
+  }
+
+  return cognitoIdToken.identities[0].userId;
 };

--- a/src/domain/cognito.ts
+++ b/src/domain/cognito.ts
@@ -48,6 +48,7 @@ type CognitoIdToken = {
   auth_time: number;
   exp: number;
   iat: number;
+  name?: string;
 };
 
 export const cognitoRegion = (): string => {
@@ -167,4 +168,14 @@ export const extractFacebookSubFromCognitoIdToken = (
   }
 
   return cognitoIdToken.identities[0].userId;
+};
+
+export const extractNameFromCognitoIdToken = (
+  cognitoIdToken: CognitoIdToken,
+): string => {
+  if (!cognitoIdToken.name) {
+    return '';
+  }
+
+  return cognitoIdToken.name;
 };

--- a/src/pages/cognito/authorized.tsx
+++ b/src/pages/cognito/authorized.tsx
@@ -52,7 +52,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const facebookSub = extractFacebookSubFromCognitoIdToken(cognitoIdToken);
 
-  const profileImageUrl = `https://graph.facebook.com/${facebookSub}/picture?type=large`;
+  const defaultImageUrl =
+    'https://avatars0.githubusercontent.com/u/42195274?s=200&v=4';
+  const profileImageUrl =
+    facebookSub === ''
+      ? defaultImageUrl
+      : `https://graph.facebook.com/${facebookSub}/picture?type=large`;
 
   // ログインIDとしても利用される、CognitoUserNameではないので注意、ここで取得するのは単なる名前なのでユニークではない
   const extractedName = extractNameFromCognitoIdToken(cognitoIdToken);

--- a/src/pages/cognito/authorized.tsx
+++ b/src/pages/cognito/authorized.tsx
@@ -50,6 +50,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const cognitoIdToken = await verifyIdToken(idToken);
 
+  // TODO 他のソーシャルログインでも対応出来るように処理を拡張する
   const facebookSub = extractFacebookSubFromCognitoIdToken(cognitoIdToken);
 
   const defaultImageUrl =

--- a/src/pages/cognito/authorized.tsx
+++ b/src/pages/cognito/authorized.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { GetServerSideProps } from 'next';
 import { findCookies } from '../../infrastructure/Cookie';
-import { verifyIdToken } from '../../domain/cognito';
+import {
+  verifyIdToken,
+  extractFacebookSubFromCognitoIdToken,
+} from '../../domain/cognito';
 
 type Props = {
-  user?: { sub: string };
+  user: {
+    sub: string;
+    profileImageUrl: string;
+  };
 };
 
 export const AuthorizedPage: React.FC<Props> = ({
@@ -14,7 +20,10 @@ export const AuthorizedPage: React.FC<Props> = ({
     <>
       {user ? (
         <div>
-          Cognitoで認証済のユーザーです。 ユーザーIDは {user.sub} です！
+          <p>Cognitoで認証済のユーザーです。 ユーザーIDは {user.sub} です！</p>
+          <p>
+            <img src={user.profileImageUrl} alt="ユーザープロフィール画像" />
+          </p>
         </div>
       ) : (
         ''
@@ -38,7 +47,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const cognitoIdToken = await verifyIdToken(idToken);
 
-  return { props: { user: { sub: cognitoIdToken.sub } } };
+  const facebookSub = extractFacebookSubFromCognitoIdToken(cognitoIdToken);
+
+  const profileImageUrl = `https://graph.facebook.com/${facebookSub}/picture?type=large`;
+
+  return { props: { user: { sub: cognitoIdToken.sub, profileImageUrl } } };
 };
 
 export default AuthorizedPage;

--- a/src/pages/cognito/authorized.tsx
+++ b/src/pages/cognito/authorized.tsx
@@ -4,11 +4,13 @@ import { findCookies } from '../../infrastructure/Cookie';
 import {
   verifyIdToken,
   extractFacebookSubFromCognitoIdToken,
+  extractNameFromCognitoIdToken,
 } from '../../domain/cognito';
 
 type Props = {
   user: {
     sub: string;
+    name: string;
     profileImageUrl: string;
   };
 };
@@ -21,6 +23,7 @@ export const AuthorizedPage: React.FC<Props> = ({
       {user ? (
         <div>
           <p>Cognitoで認証済のユーザーです。 ユーザーIDは {user.sub} です！</p>
+          <p>名前は {user.name} です！</p>
           <p>
             <img src={user.profileImageUrl} alt="ユーザープロフィール画像" />
           </p>
@@ -51,7 +54,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const profileImageUrl = `https://graph.facebook.com/${facebookSub}/picture?type=large`;
 
-  return { props: { user: { sub: cognitoIdToken.sub, profileImageUrl } } };
+  // ログインIDとしても利用される、CognitoUserNameではないので注意、ここで取得するのは単なる名前なのでユニークではない
+  const extractedName = extractNameFromCognitoIdToken(cognitoIdToken);
+  const name = extractedName === '' ? '未設定' : extractedName;
+
+  return {
+    props: { user: { sub: cognitoIdToken.sub, name, profileImageUrl } },
+  };
 };
 
 export default AuthorizedPage;


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/next-idaas/issues/37

# やった事
Facebookログイン成功時にFacebookのプロフィール画像を表示させるように変更。

前提条件として、FacebookのgraphAPIから返ってきた値の一部をCognitoUserPoolの属性値にマッピングするように対応を行っておく必要がある。（その対応に関しては https://github.com/keitakn/my-terraform/issues/40） で実施済。

# スクショ
![img](https://user-images.githubusercontent.com/11032365/99751175-06a20d80-2b25-11eb-9253-248fd4cb36bf.png)

# 実装方法

IDトークンの中に含まれる、`name` と `https://graph.facebook.com/${facebookSub}/picture?type=large` を利用する事で実現。

本当はプロフィール画像もIDトークンの中身を使えば良いのだが、画像サイズが小さく、さらにCognitoを経由した際のサイズの指定方法が分からなかったので、graphAPIを使うのが早そうなのでそのように実装した。

# 補足情報
LINE等の他の認証手段でログインした際も同様の対応が必要だが、それは別のPRで行う。