### PR TITLE
CognitoUserPoolの検証の為、Auth.signUp時にclientMetadataを渡すように変更

### DIFF
--- a/src/pages/cognito/signup.tsx
+++ b/src/pages/cognito/signup.tsx
@@ -25,6 +25,10 @@ const SignupPage: React.FC = () => {
       await Auth.signUp({
         username: email,
         password,
+        // clientMetadataがCognitoのカスタムLambdaでどのように送信されるかテスト、'0' or '1' が格納される
+        clientMetadata: {
+          subscribeNews: String(Math.floor(Math.random() * 2)),
+        },
       });
 
       setSendSignUp(true);


### PR DESCRIPTION
# issueURL
なし

# やった事
表題の通り。

`subscribeNews` はサインアップ時に渡す事が多い、メールマガジン等のお知らせを受け取る値を想定している。

送信した値は https://github.com/keitakn/go-cognito-lambda/pull/29 で利用される予定。