### PR TITLE
認可コードからCognitoのトークンを取得するサンプルコードを実装

### DIFF
--- a/src/domain/cognito.ts
+++ b/src/domain/cognito.ts
@@ -51,6 +51,19 @@ type CognitoIdToken = {
   name?: string;
 };
 
+export type CognitoTokenResponse = {
+  // eslint-disable-next-line camelcase
+  id_token: string;
+  // eslint-disable-next-line camelcase
+  access_token: string;
+  // eslint-disable-next-line camelcase
+  refresh_token: string;
+  // eslint-disable-next-line camelcase
+  expires_in: number;
+  // eslint-disable-next-line camelcase
+  token_type: 'Bearer';
+};
+
 export const cognitoRegion = (): string => {
   return process.env.NEXT_PUBLIC_COGNITO_REGION
     ? process.env.NEXT_PUBLIC_COGNITO_REGION
@@ -66,6 +79,12 @@ export const cognitoUserPoolId = (): string => {
 export const cognitoUserPoolClientId = (): string => {
   return process.env.NEXT_PUBLIC_SPA_CLIENT_ID
     ? process.env.NEXT_PUBLIC_SPA_CLIENT_ID
+    : '';
+};
+
+export const cognitoDomain = (): string => {
+  return process.env.NEXT_PUBLIC_COGNITO_DOMAIN
+    ? process.env.NEXT_PUBLIC_COGNITO_DOMAIN
     : '';
 };
 

--- a/src/pages/cognito/idp/callback.tsx
+++ b/src/pages/cognito/idp/callback.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+import {
+  cognitoDomain,
+  CognitoTokenResponse,
+  cognitoUserPoolClientId,
+} from '../../../domain/cognito';
+
+type Props = {
+  idToken: string;
+  accessToken: string;
+  refreshToken: string;
+  errorMessage: string;
+};
+
+export const CallbackPage: React.FC<Props> = ({
+  idToken,
+  accessToken,
+  refreshToken,
+  errorMessage,
+}: Props): JSX.Element => {
+  return (
+    <>
+      {errorMessage !== '' ? (
+        <h1>{errorMessage}</h1>
+      ) : (
+        <>
+          <h1>
+            <a href="https://jwt.io" target="_blank" rel="noreferrer">
+              このツール
+            </a>
+            でトークンの中身を確認出来る🐱（リフレッシュトークン以外）
+          </h1>
+          <h2>IDトークン</h2>
+          <pre>{idToken}</pre>
+
+          <h2>アクセストークン</h2>
+          <pre>{accessToken}</pre>
+
+          <h2>リフレッシュトークン</h2>
+          <pre>{refreshToken}</pre>
+        </>
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { code } = context.query;
+
+  if (!code) {
+    return {
+      props: {
+        idToken: '',
+        accessToken: '',
+        refreshToken: '',
+        errorMessage: '認可コードが設定されていません。',
+      },
+    };
+  }
+
+  const tokenEndpoint = `https://${cognitoDomain()}/oauth2/token`;
+
+  const params = new URLSearchParams();
+  params.append('grant_type', 'authorization_code');
+  params.append(
+    'redirect_uri',
+    `${String(process.env.NEXT_PUBLIC_APP_URL)}/cognito/idp/callback`,
+  );
+  params.append('code', String(code));
+  params.append('client_id', cognitoUserPoolClientId());
+
+  const response = await fetch(`${tokenEndpoint}?${params.toString()}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  });
+
+  if (!response.ok) {
+    return {
+      props: {
+        idToken: '',
+        accessToken: '',
+        refreshToken: '',
+        errorMessage: 'トークンの発行に失敗しました。',
+      },
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const tokenResponseBody: CognitoTokenResponse = await response.json();
+
+  return {
+    props: {
+      idToken: tokenResponseBody.id_token,
+      accessToken: tokenResponseBody.access_token,
+      refreshToken: tokenResponseBody.refresh_token,
+      errorMessage: '',
+    },
+  };
+};
+
+export default CallbackPage;

--- a/src/pages/cognito/idp/login.tsx
+++ b/src/pages/cognito/idp/login.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { cognitoUserPoolClientId } from '../../../domain/cognito';
+
+export const LoginPage: React.FC = (): JSX.Element => {
+  const handleLineLoginClick = () => {
+    const redirectUri = `${String(
+      process.env.NEXT_PUBLIC_APP_URL,
+    )}/cognito/idp/callback`;
+
+    const authorizeUrl = `https://${String(
+      process.env.NEXT_PUBLIC_COGNITO_DOMAIN,
+    )}/oauth2/authorize?response_type=code&client_id=${cognitoUserPoolClientId()}&redirect_uri=${redirectUri}&identity_provider=LINE`;
+
+    window.location.href = authorizeUrl;
+  };
+
+  const handleFacebookLoginClick = () => {
+    const redirectUri = `${String(
+      process.env.NEXT_PUBLIC_APP_URL,
+    )}/cognito/idp/callback`;
+
+    const authorizeUrl = `https://${String(
+      process.env.NEXT_PUBLIC_COGNITO_DOMAIN,
+    )}/oauth2/authorize?response_type=code&client_id=${cognitoUserPoolClientId()}&redirect_uri=${redirectUri}&identity_provider=Facebook`;
+
+    window.location.href = authorizeUrl;
+  };
+
+  return (
+    <>
+      <h1>Cognito + ソーシャルログイン（aws-amplify未使用バージョン）</h1>
+      <button type="button" onClick={handleLineLoginClick}>
+        LINEでログイン
+      </button>
+      <button type="button" onClick={handleFacebookLoginClick}>
+        Facebookでログイン
+      </button>
+    </>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,6 +18,11 @@ const IndexPage: React.FC = () => {
               Cognitoでサインイン済じゃないと見れないページ
             </Link>
           </li>
+          <li>
+            <Link href="/cognito/idp/login">
+              Cognito + ソーシャルログイン（aws-amplify未使用バージョン）
+            </Link>
+          </li>
         </ul>
       </div>
     </>


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/next-idaas/issues/43

# やった事
aws-amplifyを使わないでソーシャルログインを実行する機能を追加、その中で認可コードからCognitoの各種トークンを取得する処理を実装。

http://localhost:3900/cognito/idp/login でアクセス可能です。

元々ソーシャルログインは `aws-amplify` を使って実装されていました。

しかしそれらのライブラリを使えないケースを想定し今回の処理を作成しました。

https://github.com/keitakn/my-terraform/pull/45 で新しいURLを登録してあります。